### PR TITLE
Add reproducible throughput/RSS benchmark matrix for Issue #12

### DIFF
--- a/.github/workflows/issue12-prefetch-matrix.yml
+++ b/.github/workflows/issue12-prefetch-matrix.yml
@@ -1,0 +1,85 @@
+name: Issue 12 Prefetch Matrix
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'benchmarks/issue12_prefetch_matrix.sh'
+      - '.github/workflows/issue12-prefetch-matrix.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'CMakeLists.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  matrix-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build time python3
+
+      - name: Configure and build
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j "$(nproc)"
+          ctest --test-dir build --output-on-failure
+
+      - name: Create deterministic benchmark input
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('issue12-ci-input.bin')
+          block = bytes((i * 17 + 11) & 0xff for i in range(1024 * 1024))
+          with p.open('wb') as f:
+              for _ in range(128):
+                  f.write(block)
+          print(p.stat().st_size)
+          PY
+
+      - name: Run distinct prefetch matrix smoke
+        env:
+          REPEATS: '3'
+          PASSES: '2'
+          CHUNK: '8M'
+          CACHE: '32M'
+        run: |
+          bash benchmarks/issue12_prefetch_matrix.sh issue12-ci-input.bin benchmark-evidence/issue12
+          cat benchmark-evidence/issue12/summary.csv
+
+      - name: Validate matrix output
+        run: |
+          python3 - <<'PY'
+          import csv
+          from pathlib import Path
+          p = Path('benchmark-evidence/issue12/summary.csv')
+          rows = list(csv.DictReader(p.open()))
+          expected = {
+              'zero_copy_baseline',
+              'zero_copy_fixed_prefetch',
+              'bounded_fixed_prefetch',
+              'bounded_adaptive_prefetch',
+          }
+          assert {r['case'] for r in rows} == expected
+          assert all(r['checksum_stable'] == 'true' for r in rows)
+          assert all(r['checksum_matches_baseline'] == 'true' for r in rows)
+          assert all(float(r['median_gib_s']) > 0 for r in rows)
+          assert all(float(r['peak_rss_mib']) > 0 for r in rows)
+          PY
+
+      - name: Upload Issue 12 matrix evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: issue12-prefetch-matrix-evidence
+          path: benchmark-evidence/issue12/**
+          if-no-files-found: error
+          retention-days: 30

--- a/benchmarks/issue12_prefetch_matrix.sh
+++ b/benchmarks/issue12_prefetch_matrix.sh
@@ -38,27 +38,36 @@ run_case() {
   done
 }
 
-# Same input, chunk/cache ceiling, passes, binary, and host for all cases.
-run_case baseline --prefetch 0
-run_case fixed_prefetch --prefetch 2
-run_case bounded_prefetch --prefetch 2
-run_case adaptive --prefetch 2 --adaptive-prefetch --prefetch-min 1 --prefetch-max 4 --prefetch-window 8
+# Distinct controlled cases. The same input, binary, chunk size, pass count and host
+# are used throughout. Copy-cache cases share the same explicit CACHE ceiling.
+run_case zero_copy_baseline --zero-copy --prefetch 0
+run_case zero_copy_fixed_prefetch --zero-copy --prefetch 2
+run_case bounded_fixed_prefetch --prefetch 2
+run_case bounded_adaptive_prefetch --prefetch 2 --adaptive-prefetch --prefetch-min 1 --prefetch-max 4 --prefetch-window 8
 
 python3 - "$OUT" <<'PY'
 import pathlib, re, statistics, sys
 out = pathlib.Path(sys.argv[1])
-cases = ["baseline", "fixed_prefetch", "bounded_prefetch", "adaptive"]
+cases = [
+    "zero_copy_baseline",
+    "zero_copy_fixed_prefetch",
+    "bounded_fixed_prefetch",
+    "bounded_adaptive_prefetch",
+]
 rows = []
 for case in cases:
     text = (out / f"{case}.txt").read_text()
     throughput = [float(x) for x in re.findall(r"Effective stream: ([0-9.eE+-]+) GiB/s", text)]
     rss = [float(x) for x in re.findall(r"Peak RSS: ([0-9.eE+-]+) MiB", text)]
     checksums = re.findall(r"Checksum: ([0-9]+)", text)
-    rows.append((case, statistics.median(throughput), max(rss), len(set(checksums)) == 1, checksums[0] if checksums else ""))
+    if not throughput or not rss or not checksums:
+        raise SystemExit(f"missing metrics for {case}")
+    rows.append((case, statistics.median(throughput), max(rss), len(set(checksums)) == 1, checksums[0]))
 base = rows[0][1]
+reference_checksum = rows[0][4]
 with (out / "summary.csv").open("w") as f:
-    f.write("case,median_gib_s,speedup_vs_baseline,peak_rss_mib,checksum_stable,checksum\n")
+    f.write("case,median_gib_s,speedup_vs_zero_copy_baseline,peak_rss_mib,checksum_stable,checksum_matches_baseline,checksum\n")
     for case, tp, rss, stable, checksum in rows:
-        f.write(f"{case},{tp:.6f},{tp/base:.4f},{rss:.3f},{str(stable).lower()},{checksum}\n")
+        f.write(f"{case},{tp:.6f},{tp/base:.4f},{rss:.3f},{str(stable).lower()},{str(checksum == reference_checksum).lower()},{checksum}\n")
 print((out / "summary.csv").read_text())
 PY

--- a/benchmarks/issue12_prefetch_matrix.sh
+++ b/benchmarks/issue12_prefetch_matrix.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <model-or-large-file> [output-dir]" >&2
+  exit 2
+fi
+
+INPUT="$1"
+OUT="${2:-benchmark-evidence/issue12}"
+BIN="${MEMVANTA_BIN:-./build/memvanta}"
+CHUNK="${CHUNK:-64M}"
+CACHE="${CACHE:-512M}"
+PASSES="${PASSES:-3}"
+REPEATS="${REPEATS:-5}"
+
+mkdir -p "$OUT"
+{
+  echo "commit=$(git rev-parse HEAD 2>/dev/null || true)"
+  echo "input=$INPUT"
+  echo "chunk=$CHUNK"
+  echo "cache=$CACHE"
+  echo "passes=$PASSES"
+  echo "repeats=$REPEATS"
+  uname -a
+  lscpu || true
+  free -h || true
+} > "$OUT/environment.txt"
+
+run_case() {
+  local name="$1"; shift
+  : > "$OUT/${name}.txt"
+  for i in $(seq 1 "$REPEATS"); do
+    echo "=== run=$i case=$name ===" | tee -a "$OUT/${name}.txt"
+    /usr/bin/time -v "$BIN" run "$INPUT" \
+      --chunk "$CHUNK" --cache "$CACHE" --passes "$PASSES" "$@" \
+      >> "$OUT/${name}.txt" 2>> "$OUT/${name}.txt"
+  done
+}
+
+# Same input, chunk/cache ceiling, passes, binary, and host for all cases.
+run_case baseline --prefetch 0
+run_case fixed_prefetch --prefetch 2
+run_case bounded_prefetch --prefetch 2
+run_case adaptive --prefetch 2 --adaptive-prefetch --prefetch-min 1 --prefetch-max 4 --prefetch-window 8
+
+python3 - "$OUT" <<'PY'
+import pathlib, re, statistics, sys
+out = pathlib.Path(sys.argv[1])
+cases = ["baseline", "fixed_prefetch", "bounded_prefetch", "adaptive"]
+rows = []
+for case in cases:
+    text = (out / f"{case}.txt").read_text()
+    throughput = [float(x) for x in re.findall(r"Effective stream: ([0-9.eE+-]+) GiB/s", text)]
+    rss = [float(x) for x in re.findall(r"Peak RSS: ([0-9.eE+-]+) MiB", text)]
+    checksums = re.findall(r"Checksum: ([0-9]+)", text)
+    rows.append((case, statistics.median(throughput), max(rss), len(set(checksums)) == 1, checksums[0] if checksums else ""))
+base = rows[0][1]
+with (out / "summary.csv").open("w") as f:
+    f.write("case,median_gib_s,speedup_vs_baseline,peak_rss_mib,checksum_stable,checksum\n")
+    for case, tp, rss, stable, checksum in rows:
+        f.write(f"{case},{tp:.6f},{tp/base:.4f},{rss:.3f},{str(stable).lower()},{checksum}\n")
+print((out / "summary.csv").read_text())
+PY


### PR DESCRIPTION
## Summary

Adds the dedicated benchmark harness and CI smoke needed to complete the evidence phase of Issue #12 after the adaptive-prefetch mechanism landed in PR #13.

The harness runs repeated, controlled comparisons with the same input, binary, chunk size, pass count, and host. Copy-cache cases share the same explicit cache ceiling, and the four cases are now genuinely distinct.

### Matrix

1. zero-copy baseline: `--zero-copy --prefetch 0`
2. zero-copy fixed prefetch: `--zero-copy --prefetch 2`
3. bounded-cache fixed prefetch: `--prefetch 2`
4. bounded-cache adaptive prefetch: `--prefetch 2 --adaptive-prefetch --prefetch-min 1 --prefetch-max 4 --prefetch-window 8`

### Evidence produced

- repeated runs (default 5; CI smoke uses 3)
- median effective GiB/s
- speedup vs zero-copy baseline
- maximum observed peak RSS
- checksum stability and checksum equivalence to baseline
- host/CPU/memory/commit/config metadata
- machine-readable `summary.csv`

### CI validation

A dedicated `Issue 12 Prefetch Matrix` workflow now builds/tests the repository, creates a deterministic 128 MiB input, runs all four cases, validates the output schema and checksum equivalence, and uploads the matrix evidence artifact.

## Evidence boundary

Hosted GitHub Actions results validate the correctness and reproducibility of the benchmark harness and can provide runner-scoped streaming observations. They are **not** evidence of universal CPU inference performance and do not by themselves complete Issue #12's real-model prompt/decode throughput acceptance criteria.

The final Issue #12 conclusion still requires same-machine physical-CPU measurements with real-model inference metrics (prompt-processing tok/s, generation tok/s/latency, peak RSS and correctness) under a controlled baseline-vs-adaptive setup.

Partially addresses #12.