### PR TITLE
Add real-model mmap prefetch A/B experiment for Issue #12

### DIFF
--- a/.github/workflows/issue12-real-prefetch-ab.yml
+++ b/.github/workflows/issue12-real-prefetch-ab.yml
@@ -1,0 +1,79 @@
+name: Issue 12 Real Prefetch A/B
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'benchmarks/issue12_real_prefetch_ab.cpp'
+      - '.github/workflows/issue12-real-prefetch-ab.yml'
+      - 'CMakeLists.txt'
+      - 'src/**'
+      - 'include/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  real-prefetch-ab:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MODEL: stories15M-q4_0.gguf
+      MODEL_URL: https://huggingface.co/ggml-org/models-moved/resolve/main/tinyllamas/stories15M-q4_0.gguf?download=true
+      MODEL_SHA256: 66967fbece6dbe97886593fdbb73589584927e29119ec31f08090732d1861739
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build curl python3
+      - name: Configure and build
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j "$(nproc)"
+          ctest --test-dir build --output-on-failure
+      - name: Download and verify TinyStories
+        run: |
+          curl -L --fail --retry 3 --retry-delay 2 "$MODEL_URL" -o "$MODEL"
+          echo "$MODEL_SHA256  $MODEL" | sha256sum -c -
+      - name: Run A/B matrix
+        run: |
+          mkdir -p benchmark-evidence/issue12-real-prefetch
+          for mode in none fixed adaptive; do
+            ./build/memvanta_issue12_real_prefetch_ab --model "$MODEL" --mode "$mode" --threads 4 --reps 5 --ctx 128 --prompt 32 --gen 8 --depth 2 --min-depth 1 --max-depth 4 --csv "benchmark-evidence/issue12-real-prefetch/${mode}.csv" | tee "benchmark-evidence/issue12-real-prefetch/${mode}.txt"
+          done
+          python3 - <<'PY'
+          import csv,re
+          from pathlib import Path
+          out=Path('benchmark-evidence/issue12-real-prefetch')
+          rows=[]
+          for mode in ('none','fixed','adaptive'):
+              t=(out/f'{mode}.txt').read_text()
+              m=re.search(r'pp_tps_median=([0-9.eE+-]+) tg_tps_median=([0-9.eE+-]+) peak_rss_mib=([0-9.eE+-]+) final_depth=([0-9]+)',t)
+              assert m, mode
+              rows.append((mode,*m.groups()))
+          with (out/'summary.csv').open('w',newline='') as f:
+              w=csv.writer(f);w.writerow(['mode','pp_tps_median','tg_tps_median','peak_rss_mib','final_depth']);w.writerows(rows)
+          print((out/'summary.csv').read_text())
+          PY
+      - name: Validate evidence
+        run: |
+          python3 - <<'PY'
+          import csv
+          from pathlib import Path
+          rows=list(csv.DictReader(Path('benchmark-evidence/issue12-real-prefetch/summary.csv').open()))
+          assert [r['mode'] for r in rows]==['none','fixed','adaptive']
+          for r in rows:
+              assert float(r['pp_tps_median'])>0
+              assert float(r['tg_tps_median'])>0
+              assert float(r['peak_rss_mib'])>0
+          PY
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: issue12-real-prefetch-ab-evidence
+          path: benchmark-evidence/issue12-real-prefetch/**
+          if-no-files-found: error
+          retention-days: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ add_executable(memvanta_real src/real_main.cpp)
 target_link_libraries(memvanta_real PRIVATE memvanta_core)
 add_executable(memvanta_real_bench benchmarks/real_model_bench.cpp)
 target_link_libraries(memvanta_real_bench PRIVATE memvanta_core)
+add_executable(memvanta_issue12_real_prefetch_ab benchmarks/issue12_real_prefetch_ab.cpp)
+target_link_libraries(memvanta_issue12_real_prefetch_ab PRIVATE memvanta_core)
 add_executable(memvanta_profile benchmarks/profile_bench.cpp)
 target_link_libraries(memvanta_profile PRIVATE memvanta_core)
 

--- a/benchmarks/issue12_real_prefetch_ab.cpp
+++ b/benchmarks/issue12_real_prefetch_ab.cpp
@@ -1,0 +1,58 @@
+#include "memvanta/llama_model.hpp"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <sys/resource.h>
+#include <vector>
+
+using Clock = std::chrono::steady_clock;
+
+namespace {
+double rss_mib(){ rusage r{}; getrusage(RUSAGE_SELF,&r); return r.ru_maxrss/1024.0; }
+std::vector<int> fixed_tokens(std::size_t n,std::size_t vocab){std::vector<int>x(n);for(std::size_t i=0;i<n;++i)x[i]=static_cast<int>((i*1543+17)%std::max<std::size_t>(vocab,1));return x;}
+double median(std::vector<double> v){std::sort(v.begin(),v.end());return v.size()%2?v[v.size()/2]:(v[v.size()/2-1]+v[v.size()/2])/2.0;}
+
+void drop_model_pages(const memvanta::LlamaModel& m){
+    const auto& mf=m.gguf().mapped_file();
+    for(const auto& t:m.gguf().tensors()) mf.advise_dontneed(t.offset,t.nbytes);
+}
+
+void prefetch_layers(const memvanta::LlamaModel& m,std::size_t depth){
+    if(!depth)return;
+    const auto& mf=m.gguf().mapped_file();
+    const auto& ts=m.gguf().tensors();
+    std::size_t layers=m.config().n_layer;
+    depth=std::min(depth,layers);
+    for(const auto& t:ts){
+        if(t.name=="token_embd.weight"||t.name=="output.weight"||t.name=="output_norm.weight") mf.advise_willneed(t.offset,t.nbytes);
+    }
+    for(std::size_t li=0;li<depth;++li){
+        const std::string p="blk."+std::to_string(li)+".";
+        for(const auto& t:ts) if(t.name.rfind(p,0)==0) mf.advise_willneed(t.offset,t.nbytes);
+    }
+}
+}
+
+int main(int argc,char**argv){
+    try{
+        std::string model,mode="none",csv; unsigned threads=4,reps=5; std::size_t ctx=128,prompt_n=32,gen_n=8,depth=2,min_depth=1,max_depth=4;
+        for(int i=1;i<argc;++i){std::string a=argv[i];auto val=[&](){if(i+1>=argc)throw std::runtime_error("missing value for "+a);return std::string(argv[++i]);};
+            if(a=="--model")model=val();else if(a=="--mode")mode=val();else if(a=="--threads")threads=std::stoul(val());else if(a=="--reps")reps=std::stoul(val());else if(a=="--ctx")ctx=std::stoull(val());else if(a=="--prompt")prompt_n=std::stoull(val());else if(a=="--gen")gen_n=std::stoull(val());else if(a=="--depth")depth=std::stoull(val());else if(a=="--min-depth")min_depth=std::stoull(val());else if(a=="--max-depth")max_depth=std::stoull(val());else if(a=="--csv")csv=val();else throw std::runtime_error("unknown arg: "+a);}
+        if(model.empty())throw std::runtime_error("--model required"); if(mode!="none"&&mode!="fixed"&&mode!="adaptive")throw std::runtime_error("--mode must be none|fixed|adaptive");
+        memvanta::LlamaModel m(model,threads,ctx); prompt_n=std::min(prompt_n,m.config().n_ctx/2);gen_n=std::min(gen_n,m.config().n_ctx/4);auto prompt=fixed_tokens(prompt_n,m.config().vocab);auto seed=fixed_tokens(std::min<std::size_t>(16,m.config().n_ctx-gen_n),m.config().vocab);memvanta::Sampler greedy({0,1,1});
+        std::vector<double>pp,tg;std::size_t current=std::clamp(depth,min_depth,max_depth);double prev_total=0;
+        for(unsigned r=0;r<reps;++r){
+            drop_model_pages(m); if(mode=="fixed")prefetch_layers(m,depth);else if(mode=="adaptive")prefetch_layers(m,current);
+            m.reset();auto a=Clock::now();m.prefill(prompt,16,true);auto b=Clock::now();double pp_s=std::chrono::duration<double>(b-a).count();pp.push_back(prompt.size()/pp_s);
+            m.reset();m.prefill(seed,16,false);int cur=17%m.config().vocab;auto c=Clock::now();for(std::size_t i=0;i<gen_n;++i)cur=greedy.sample(m.forward(cur,true));auto d=Clock::now();double tg_s=std::chrono::duration<double>(d-c).count();tg.push_back(gen_n/tg_s);
+            double total=pp_s+tg_s;if(mode=="adaptive"&&r>0){if(total>prev_total*1.03&&current>min_depth)--current;else if(total<prev_total*0.97&&current<max_depth)++current;}prev_total=total;
+        }
+        std::cout<<"mode="<<mode<<" threads="<<threads<<" pp_tps_median="<<median(pp)<<" tg_tps_median="<<median(tg)<<" peak_rss_mib="<<rss_mib()<<" final_depth="<<current<<"\n";
+        if(!csv.empty()){std::ofstream f(csv);f<<"rep,pp_tps,tg_tps\n";for(std::size_t i=0;i<pp.size();++i)f<<i+1<<","<<pp[i]<<","<<tg[i]<<"\n";}
+        return 0;
+    }catch(const std::exception&e){std::cerr<<"error: "<<e.what()<<"\n";return 2;}
+}


### PR DESCRIPTION
## Summary

Adds a real-model CPU inference A/B experiment for Issue #12 using MemVanta's existing GGUF mmap and `advise_willneed`/`advise_dontneed` hooks.

This is intentionally an **experimental benchmark layer**, not yet a production `LlamaModel` policy. It lets us measure whether mmap weight prefetching produces a real prompt/decode benefit before moving the mechanism into the inference loop.

### Modes

- `none`: no explicit weight prefetch
- `fixed`: prefetch a fixed number of early transformer layers
- `adaptive`: adjust prefetch depth between repeated inference runs using observed prompt+decode time, bounded by min/max depth

Each repetition first issues `DONTNEED` for model tensor ranges so the hosted runner measures a cold-page-sensitive comparison rather than simply reusing already-resident pages.

### Metrics

- real-model prompt-processing tok/s
- real-model generation tok/s
- peak RSS
- final adaptive depth
- per-repetition CSV evidence

### CI

Adds `Issue 12 Real Prefetch A/B`, which downloads and verifies TinyStories GGUF, builds/tests MemVanta, runs none/fixed/adaptive modes under identical 4-thread settings, validates positive metrics, and uploads the evidence artifact.

## Evidence boundary

This experiment answers whether mmap prefetch hints are promising for real inference under controlled cold-page conditions. It does **not** yet make prefetch a default or claim universal throughput improvement. If the A/B result is favorable, the next PR should move the bounded look-ahead policy into `LlamaModel` layer execution; if not, Issue #12 should avoid promoting this mechanism.

Partially addresses #12.