### PR TITLE
Test loop-unrolled GGUF kernels under 7B FFN gate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ add_library(memvanta_core
     src/llama_model.cpp)
 target_include_directories(memvanta_core PUBLIC include)
 target_compile_options(memvanta_core PRIVATE -O3 -Wall -Wextra -Wpedantic)
+# The GGUF projection kernels are dominated by small fixed-trip inner loops.
+# Let the compiler unroll only this translation unit so the 7B FFN A/B gate
+# can validate whether reduced loop/control overhead improves the Q4 hotspot
+# without changing numerical behavior or broadening code-size impact globally.
+set_source_files_properties(src/gguf_kernels.cpp PROPERTIES COMPILE_OPTIONS "-funroll-loops")
 if(MEMVANTA_NATIVE)
   target_compile_options(memvanta_core PRIVATE -march=native)
 endif()


### PR DESCRIPTION
## Summary

Adds a narrowly-scoped compiler optimization candidate for the GGUF projection kernels by enabling `-funroll-loops` only for `src/gguf_kernels.cpp`.

### Why

The latest 7B profile shows projection kernels dominate runtime and FFN is the largest hotspot. The kernel source contains small fixed-trip inner loops in Q4/Q8 paths, so loop unrolling is a low-risk candidate worth measuring before a larger handwritten AVX rewrite.

### Safety

- no numerical algorithm changes
- no global compiler-flag change
- normal unit/tokenizer tests still apply
- PR #21's Seven Billion FFN Kernel A/B gate compares this branch against current `main` on the same runner
- keep only if FFN/end-to-end evidence is non-regressing within the gate and RSS stays within guardrail

Partially addresses #12.